### PR TITLE
Fix html_writer and moodle_url imports

### DIFF
--- a/mod/pdfflip/classes/output/renderer.php
+++ b/mod/pdfflip/classes/output/renderer.php
@@ -3,6 +3,8 @@ namespace mod_pdfflip\output;
 
 use plugin_renderer_base;
 use context;
+use html_writer;
+use moodle_url;
 
 class renderer extends plugin_renderer_base {
     public function render_pdfflip(\stdClass $pdfflip, context $context): string {


### PR DESCRIPTION
## Summary
- import html_writer and moodle_url in output renderer

## Testing
- `php -l mod/pdfflip/classes/output/renderer.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849f58fa10083248df28ea54a3f03c0