### PR TITLE
Adjust pdfflip view rendering order

### DIFF
--- a/mod/pdfflip/view.php
+++ b/mod/pdfflip/view.php
@@ -26,9 +26,9 @@ $PAGE->set_title(format_string($pdfflip->name));
 $PAGE->set_heading(format_string($course->fullname));
 
 $renderer = $PAGE->get_renderer('mod_pdfflip');
+$content = $renderer->render_pdfflip($pdfflip, $context);
 
 echo $OUTPUT->header();
-
-echo $renderer->render_pdfflip($pdfflip, $context);
+echo $content;
 
 echo $OUTPUT->footer();


### PR DESCRIPTION
## Summary
- render the pdfflip content before printing the page header

## Testing
- `php -l mod/pdfflip/view.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849f826f1508324af1d49c04f8d96a5